### PR TITLE
Update dfoil.py to accept Dstats = 0

### DIFF
--- a/dfoil.py
+++ b/dfoil.py
@@ -192,7 +192,7 @@ class DataWindow(object):
             pvalues = [pvalue_cutoffs[0]]
         dfoil_signature = []
         for j, statname in enumerate(STATNAMES[mode]):
-            if self.stats[statname]['Pvalue'] == 1:
+            if self.stats[statname]['Pvalue'] == -1:
                 self.stats['signature'] = 0
                 return ''
             if self.stats[statname]['Pvalue'] <= pvalues[j]:
@@ -268,12 +268,12 @@ def dcrunch(left_term, right_term, mincount=0):
     result['right'] = right_term
     result['Dtotal'] = left_term + right_term
     if not left_term + right_term:
-        result['Pvalue'] = 1.0
+        result['Pvalue'] = -1.0
         result['chisq'] = 0
         result['D'] = 0
     elif left_term + right_term < mincount:
         result['chisq'] = 0
-        result['Pvalue'] = 1.0
+        result['Pvalue'] = -1.0
         result['D'] = (float(left_term - right_term) /
                        (left_term + right_term))
     else:


### PR DESCRIPTION
In some cases, D-statistics may legitimately equal 0 (with P=1).

Previous behavior:
DFOIL was checking against the minimum count value, changing P=1 in those cases, and then later returning an introgression signature of "na" if P=1 for any D-stat.

New behavior:
DFOIL checks against the minimum count value, changing P=-1 in those cases, and returns an introgression signature of "na" if P=-1 for any D-stat. Scenarios where a D-stat = 0 with P=1 are treated normally and should pass a "0" to the resulting introgression signature.